### PR TITLE
[FIX] Bug no Registrar URL for .ec (google.ec) and .fi (99.fi)

### DIFF
--- a/parse_whois_socket.py
+++ b/parse_whois_socket.py
@@ -91,7 +91,7 @@ class ParseWhoisSocket:
         raw_registrar_url = str(data)
         if tld_domain in ['be', 'gh', 'gi', 'gl', 'la', 'kw', 'ps',
                           'rw', 'so', 'vg', 'bh', 'bm', 'do', 'fm',
-                          'gd', 'pw', 'ke']:
+                          'gd', 'pw', 'ke', 'rw']:
             pre_raw_registrar_url = []
             if tld_domain == 'be':
                 pre_raw_registrar_url = re.findall('Website:(.*?)Nameservers:', raw_registrar_url, re.DOTALL | re.IGNORECASE)
@@ -100,7 +100,7 @@ class ParseWhoisSocket:
             # Related DONUTS, CoCCA, CNIC
             elif tld_domain in ['gi', 'gl', 'la', 'kw', 'ps', 'rw',
                                 'so', 'vg', 'bh', 'bm', 'do', 'fm',
-                                'gd', 'pw', 'ke']:
+                                'gd', 'pw', 'ke', 'rw']:
                 pre_raw_registrar_url = re.findall('Registrar URL:(.*?)Updated Date:', raw_registrar_url, re.DOTALL | re.IGNORECASE)
             
             if pre_raw_registrar_url:
@@ -128,6 +128,12 @@ class ParseWhoisSocket:
             raw_registrar_url = registrar_url_short_replace(data, 'Registrar:(.*?)Relevant dates:', 'URL:', 'Registrar URL:')
         elif tld_domain == 'de':
             raw_registrar_url = ''
+        elif tld_domain == 'ec':
+            # Bug no Registrar URL. Ex: google.ec
+            raw_registrar_url = registrar_url_short_replace(data, 'Registrar URL:(.*?)Creation Date:', ' ', 'Registrar URL: ')
+        elif tld_domain == 'fi':
+            # Bug no Registrar URL. Ex: 99.fi
+            raw_registrar_url = registrar_url_short_replace(data, 'www................:(.*?)>>> Last update of WHOIS database', ' ', 'Registrar URL: ')
         
         registrar_url = re.findall('(Registrar URL:|website:|www..................:|'
                                    'Referral URL:|www................:|registrar info:|'


### PR DESCRIPTION
```
 ---Domain Name: google.ec
Registrar URL: 
Creation Date: 2003-10-16T23:00:00.0Z
Registry Expiry Date: 2024-10-16T23:00:00.0Z
Registrar Registration Expiration Date: 2024-10-16T23:00:00.0Z
Registrar: MarkMonitor Inc.
Registrar Abuse Contact Email: ccops@markmonitor.com
Registrar Abuse Contact Phone: +1.2083895740
Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Registry Registrant ID: Redacted | Registry Policy
Registrant Name: Domain Administrator
Registrant Organization: Google LLC
Registrant Street: Redacted | Registry Policy
Registrant City: Redacted | Registry Policy
Registrant State/Province: Redacted | Registry Policy
Registrant Postal Code: Redacted | Registry Policy
Registrant Country: US
Registrant Phone: Redacted | Registry Policy
Registrant Fax: Redacted | Registry Policy
Registrant Email: Redacted | Registry Policy
Registry Admin ID: Redacted | Registry Policy
Admin Name: Domain Administrator
Admin Organization: Google LLC
Admin Street: Redacted | Registry Policy
Admin City: Redacted | Registry Policy
Admin State/Province: Redacted | Registry Policy
Admin Postal Code: Redacted | Registry Policy
Admin Country: US
Admin Phone: Redacted | Registry Policy
Admin Fax: Redacted | Registry Policy
Admin Email: Redacted | Registry Policy
Name Server: ns1.google.com
Name Server: ns2.google.com
Name Server: ns3.google.com
Name Server: ns4.google.com
>>> Last update of WHOIS database: 2023-11-14T15:32:23.135Z <<<

For more information on Whois status codes, please visit https://icann.org/epp

Los datos detallados a continuación por NIC.EC es información pública cuyo propósito es
únicamente informativo que sirve para la obtención de la información acerca de o
relacionado con los registros de un Nombre de Dominio. Los datos se muestran de acuerdo
a los datos de NIC.EC en la última actualización de su base de datos. Al realizar una
búsqueda de WHOIS de un dominio, usted declara y acepta que los datos serán utilizados
solo para fines legales y que no utilizara los datos para envíos masivos no solicitados
de correo electrónico o para publicidad o fines comerciales no solicitados.

Full WHOIS: https://nic.ec
```

```
domain.............: 99.fi
status.............: Registered
created............: 4.7.2012 22:02:28
expires............: 24.6.2024 12:40:35
available..........: 24.7.2024 12:40:35
modified...........: 29.9.2023 14:18:41
RegistryLock.......: no

Nameservers

nserver............: ns8384.hostgator.com [OK]
nserver............: ns8383.hostgator.com [OK]

DNSSEC

dnssec.............: no

Holder

holder.............: Private person

Registrar

registrar..........: Manhattan Media
www................: 

>>> Last update of WHOIS database: 14.11.2023 17:00:48 (EET) <<<


Copyright (c) Finnish Transport and Communications Agency Traficom
```