### PR TITLE
[ADD] Add WHOIS, RDAP for .ad domain

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "Python: Current File",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "python": "${workspaceFolder}/venv/bin/python3.11",
             "program": "${workspaceFolder}/main.py",

--- a/cctld.py
+++ b/cctld.py
@@ -6,7 +6,7 @@ class WhOISccTLD:
     def get_whois_server(self, extension):
         dict_extension = {
             'ac': 'whois.nic.ac',
-            # 'ad': 'https://www.andorratelecom.ad/',
+            'ad': 'whois.nic.ad',
             'ae': 'whois.aeda.net.ae',
             'af': '185.17.239.201', #'whois.nic.af',
             'ag': 'whois.nic.ag',

--- a/static/src/js/rdap_data_extend.js
+++ b/static/src/js/rdap_data_extend.js
@@ -108,6 +108,9 @@ var rdap_data_extend = `
     "td": {
         "rdap": "https://rdap.nic.td/"
     },
+    "ad": {
+        "rdap": "https://rdap.nic.ad/"
+    },
     "br.com": {
         "rdap": "https://rdap.centralnic.com/br.com/"
     },

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,13 +128,13 @@
                             Creation Date: 15/08/2023
                         </p>
                         <p>
-                            Updated Date: 26/04/2024
+                            Updated Date: 02/05/2024
                         </p>
                         <p>
                             Author: ALIENSOFTWARE
                         </p>
                         <p>
-                            Version: 3.0.16-dev
+                            Version: 3.0.17-dev
                         </p>
                         <p>
                             Support: https://check.rs


### PR DESCRIPTION
https://domainincite.com/29820-ad-domains-to-go-global-soon

From 22.10.2024 any natural or legal person will be able to register an available and live .ad domain, through any of the accredited registrars, following the standard domain registration procedure, meaning that requests will be handled automatically and the domains will be assigned in strict order of arrival ( first-come, first-served ). No priority will need to be proven, and applications will not be subject to prior validation.