### PR TITLE
[ADD] Add RDAP .fj domain

### DIFF
--- a/static/src/js/rdap_data_extend.js
+++ b/static/src/js/rdap_data_extend.js
@@ -111,6 +111,9 @@ var rdap_data_extend = `
     "et": {
         "rdap": "https://rdap.ethiotelecom.et/rdap/"
     },
+    "fj": {
+        "rdap": "https://www.whois.fj/"
+    },
     "br.com": {
         "rdap": "https://rdap.centralnic.com/br.com/"
     },

--- a/templates/index.html
+++ b/templates/index.html
@@ -145,13 +145,13 @@
                             Creation Date: 15/08/2023
                         </p>
                         <p>
-                            Updated Date: 15/04/2025
+                            Updated Date: 16/04/2025
                         </p>
                         <p>
                             Author: MAI TIẾN DŨNG
                         </p>
                         <p>
-                            Version: 3.3.39
+                            Version: 3.3.40
                         </p>
                         <p>
                             Support: https://check.rs


### PR DESCRIPTION
Monday, April 14, 2025
Please be advised that the .fj platform is currently undergoing an upgrade. As a result, the WHOIS service is temporarily unavailable. We would also like to inform you that the WHOIS protocol has been officially deprecated. Going forward, the .fj platform will use the Registration Data Access Protocol (RDAP) for domain ownership verification and related queries.

Thank you for your understanding and continued support.