### PR TITLE
[REM] Remove unittest reserved a cv domain

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -146,13 +146,13 @@
                             Creation Date: 15/08/2023
                         </p>
                         <p>
-                            Updated Date: 30/06/2025
+                            Updated Date: 13/07/2025
                         </p>
                         <p>
                             Author: MAI TIẾN DŨNG
                         </p>
                         <p>
-                            Version: 3.3.53
+                            Version: 3.3.54
                         </p>
                         <p>
                             Support: https://check.rs

--- a/tests/test_cctld_c.py
+++ b/tests/test_cctld_c.py
@@ -336,33 +336,33 @@ class TestC(unittest.TestCase):
         
         self.assertEqual(data['parse']['domain_status'][0], 'Reserved Domain')
     
-    def test_reserved_domain_cv(self):
-        response = client.post(
-            '/api/v1/whois',
-            headers={'X-Requested-With': 'XMLHttpRequest'},
-            json={"domain": "whois.cv"},
-        )
-        data = json.loads(response.content)
+    # def test_reserved_domain_cv(self):
+    #     response = client.post(
+    #         '/api/v1/whois',
+    #         headers={'X-Requested-With': 'XMLHttpRequest'},
+    #         json={"domain": "whois.cv"},
+    #     )
+    #     data = json.loads(response.content)
         
-        if not data['status']:
-            print('Please check .cv whois server - Reserved Domains!')
-            return
+    #     if not data['status']:
+    #         print('Please check .cv whois server - Reserved Domains!')
+    #         return
         
-        resp_data = data.get('result', '')
-        if resp_data.find('Server can\'t process your request at the moment') > -1:
-            print('The .cv whois server was busy!')
-            return
+    #     resp_data = data.get('result', '')
+    #     if resp_data.find('Server can\'t process your request at the moment') > -1:
+    #         print('The .cv whois server was busy!')
+    #         return
         
-        self.assertEqual(data['parse']['registrar'], '')
-        self.assertEqual(data['parse']['registrar_url'], '')
-        self.assertEqual(len(data['parse']['domain_status']), 1)
-        self.assertEqual(len(data['parse']['nameservers']), 0)
+    #     self.assertEqual(data['parse']['registrar'], '')
+    #     self.assertEqual(data['parse']['registrar_url'], '')
+    #     self.assertEqual(len(data['parse']['domain_status']), 1)
+    #     self.assertEqual(len(data['parse']['nameservers']), 0)
         
-        self.assertEqual(data['parse']['creation_date'], '')
-        self.assertEqual(data['parse']['updated_date'], '')
-        self.assertEqual(data['parse']['expiry_date'], '')
+    #     self.assertEqual(data['parse']['creation_date'], '')
+    #     self.assertEqual(data['parse']['updated_date'], '')
+    #     self.assertEqual(data['parse']['expiry_date'], '')
         
-        self.assertEqual(data['parse']['domain_status'][0], 'Reserved Domain')
+    #     self.assertEqual(data['parse']['domain_status'][0], 'Reserved Domain')
     
     def test_reserved_domain_cx(self):
         response = client.post(


### PR DESCRIPTION
Domain Name: whois.cv
Registry Domain ID: 101905-niccv
Updated Date: 
Creation Date: 2025-07-10T00:00:00Z
Registry Expiry Date: 2026-07-09T00:00:00Z
Registrar Registration Expiration Date: 2026-07-09T00:00:00Z
Registrar: Premium Name Services
Registrar Street Address: 16701 Tomcat Dr, Round Rock, TX 78681
Registrar Email: premium@ola.cv
Domain Status: active https://icann.org/epp#active
Registrant Name: Unknown
Name Server: ns1.namepros-dns.com
Name Server: 6f638pf2d6pbj58ds6brrj65pbfzdm66.ns.namepros-dns.is
DNSSEC: unsigned
>>> Last update of WHOIS database: 2025-07-13T01:38:40.041Z <<<

For more information on domain status codes, please visit https://icann.org/epp

TERMS OF USE: You are not authorized to access or query our WHOIS database through the use of electronic processes that are high-volume and automated.  This WHOIS database is provided by as a service to the internet community.

The data is for information purposes only. We do not guarantee its accuracy. By submitting a WHOIS query, you agree to abide by the following terms of use: You agree that you may use this Data only for lawful purposes and that under no circumstances will you use this Data to: (1) allow, enable, or otherwise support the transmission of mass unsolicited, commercial advertising or solicitations via e-mail, telephone, or facsimile; or (2) enable high volume, automated, electronic processes that apply to CoCCA it's members (or CoCCA or member computer systems). The compilation, repackaging, dissemination or other use of this Data is expressly prohibited.